### PR TITLE
Fix PDF render crash by updating bitmap on main thread

### DIFF
--- a/app/src/main/java/com/example/scoreturner/ReaderScreen.kt
+++ b/app/src/main/java/com/example/scoreturner/ReaderScreen.kt
@@ -55,10 +55,10 @@ fun ReaderScreen(
             WorkType.IMAGE_SET -> workWithPages?.pages?.size ?: 1
         }
         if (w.type == WorkType.PDF) {
-            withContext(Dispatchers.IO) {
-                val bmp = PdfPageCache.getPage(ctx, Uri.parse(w.sourceUri), pagerState.currentPage, scale = 3)
-                currentBitmap = bmp
+            val bmp = withContext(Dispatchers.IO) {
+                PdfPageCache.getPage(ctx, Uri.parse(w.sourceUri), pagerState.currentPage, scale = 3)
             }
+            currentBitmap = bmp
         }
     }
 


### PR DESCRIPTION
## Summary
- Avoid updating `currentBitmap` from a background thread when rendering PDFs
- Render the PDF page on `Dispatchers.IO` and apply the result on the main thread to prevent crashes during PDF loading

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a270cf13c8321af69b44ec37e7c35