### PR TITLE
Fix PDF page rendering scope in ReaderScreen

### DIFF
--- a/app/src/main/java/com/example/scoreturner/ReaderScreen.kt
+++ b/app/src/main/java/com/example/scoreturner/ReaderScreen.kt
@@ -68,7 +68,6 @@ fun ReaderScreen(
                 currentBitmap = null
                 errorMessage = e.stackTraceToString()
             }
-            currentBitmap = bmp
         }
     }
 


### PR DESCRIPTION
## Summary
- remove leftover `currentBitmap = bmp` outside try block to avoid unresolved reference error during compilation

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a5ed02a4c832186d8f6ddd65ebeaf