### PR TITLE
Speed up Gradle builds

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
-    id("org.jetbrains.kotlin.kapt")
+    id("com.google.devtools.ksp")
 }
 
 android {
@@ -81,7 +81,7 @@ dependencies {
     // Room
     implementation("androidx.room:room-runtime:2.6.1")
     implementation("androidx.room:room-ktx:2.6.1")
-    kapt("androidx.room:room-compiler:2.6.1")
+    ksp("androidx.room:room-compiler:2.6.1")
 
     // Coil
     implementation("io.coil-kt:coil-compose:2.6.0")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
     id("com.android.application") version "8.5.1" apply false
     id("org.jetbrains.kotlin.android") version "1.9.24" apply false
-    id("org.jetbrains.kotlin.kapt") version "1.9.24" apply false
+    id("com.google.devtools.ksp") version "1.9.24-1.0.20" apply false
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,9 @@
 org.gradle.jvmargs=-Xmx3g -Dfile.encoding=UTF-8
+org.gradle.daemon=true
+org.gradle.parallel=true
+org.gradle.caching=true
+org.gradle.configuration-cache=true
 android.useAndroidX=true
-android.enableJetifier=true
+android.enableJetifier=false
 kotlin.code.style=official
+kotlin.incremental=true


### PR DESCRIPTION
## Summary
- Enable daemon, parallel execution, caching and configuration cache; disable Jetifier
- Migrate Room annotation processing from KAPT to KSP

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a661ecb0c832193a1c6535ce46363