### PR TITLE
Publish APK release asset

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -55,3 +55,13 @@ jobs:
         with:
           name: app-release
           path: app/build/outputs/apk/release/*.apk
+
+      - name: Publish APK to GitHub Release
+        uses: softprops/action-gh-release@v1
+        if: github.ref == 'refs/heads/main'
+        with:
+          files: app/build/outputs/apk/release/*.apk
+          tag_name: build-${{ github.run_number }}
+          name: "Build ${{ github.run_number }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- publish app APK directly to GitHub Releases for each run

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b59c1d2588321a634d687b8f4a393