### PR TITLE
Add custom icons for navigation, camera, and fullscreen

### DIFF
--- a/app/src/main/java/com/example/scoreturner/ReaderScreen.kt
+++ b/app/src/main/java/com/example/scoreturner/ReaderScreen.kt
@@ -13,16 +13,16 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Fullscreen
-import androidx.compose.material.icons.filled.FullscreenExit
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.asImageBitmap
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
@@ -32,6 +32,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlin.math.max
+import com.example.scoreturner.R
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
 @Composable
@@ -163,17 +164,31 @@ fun ReaderScreen(
                         Modifier.align(Alignment.BottomCenter).padding(16.dp),
                         horizontalArrangement = Arrangement.spacedBy(12.dp)
                     ) {
-                        FilledTonalButton(onClick = onPrev) { Text(t("Назад")) }
-                        FilledTonalButton(onClick = onNext) { Text(t("Вперёд")) }
+                        FilledTonalButton(onClick = onPrev) {
+                            Icon(
+                                painterResource(R.drawable.ic_arrow_back),
+                                contentDescription = t("Назад")
+                            )
+                        }
+                        FilledTonalButton(onClick = onNext) {
+                            Icon(
+                                painterResource(R.drawable.ic_arrow_forward),
+                                contentDescription = t("Вперёд")
+                            )
+                        }
                         FilledTonalButton(onClick = {
                             if (cameraGranted) cameraGranted = false
                             else askCamera.launch(Manifest.permission.CAMERA)
                         }) {
-                            Text(t(if (cameraGranted) "Камера ✓" else "Камера"))
+                            Icon(
+                                painterResource(R.drawable.ic_camera),
+                                contentDescription = t(if (cameraGranted) "Камера ✓" else "Камера"),
+                                tint = if (cameraGranted) Color(0xFF4CAF50) else LocalContentColor.current
+                            )
                         }
                         FilledTonalButton(onClick = { fullScreen = true; controlsVisible = false }) {
                             Icon(
-                                Icons.Default.Fullscreen,
+                                painterResource(R.drawable.ic_fullscreen),
                                 contentDescription = t("На весь экран")
                             )
                         }
@@ -183,18 +198,32 @@ fun ReaderScreen(
                         Modifier.align(Alignment.BottomCenter).padding(16.dp),
                         horizontalArrangement = Arrangement.spacedBy(12.dp)
                     ) {
-                        FilledTonalButton(onClick = { onPrev(); controlsVisible = true }) { Text(t("Назад")) }
-                        FilledTonalButton(onClick = { onNext(); controlsVisible = true }) { Text(t("Вперёд")) }
+                        FilledTonalButton(onClick = { onPrev(); controlsVisible = true }) {
+                            Icon(
+                                painterResource(R.drawable.ic_arrow_back),
+                                contentDescription = t("Назад")
+                            )
+                        }
+                        FilledTonalButton(onClick = { onNext(); controlsVisible = true }) {
+                            Icon(
+                                painterResource(R.drawable.ic_arrow_forward),
+                                contentDescription = t("Вперёд")
+                            )
+                        }
                         FilledTonalButton(onClick = {
                             controlsVisible = true
                             if (cameraGranted) cameraGranted = false
                             else askCamera.launch(Manifest.permission.CAMERA)
                         }) {
-                            Text(t(if (cameraGranted) "Камера ✓" else "Камера"))
+                            Icon(
+                                painterResource(R.drawable.ic_camera),
+                                contentDescription = t(if (cameraGranted) "Камера ✓" else "Камера"),
+                                tint = if (cameraGranted) Color(0xFF4CAF50) else LocalContentColor.current
+                            )
                         }
                         FilledTonalButton(onClick = { fullScreen = false; controlsVisible = false }) {
                             Icon(
-                                Icons.Default.FullscreenExit,
+                                painterResource(R.drawable.ic_fullscreen_exit),
                                 contentDescription = t("Выйти из полноэкранного режима")
                             )
                         }

--- a/app/src/main/res/drawable/ic_arrow_back.xml
+++ b/app/src/main/res/drawable/ic_arrow_back.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#000000"
+        android:pathData="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_arrow_forward.xml
+++ b/app/src/main/res/drawable/ic_arrow_forward.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#000000"
+        android:pathData="M12 4l-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_camera.xml
+++ b/app/src/main/res/drawable/ic_camera.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#000000"
+        android:pathData="M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_fullscreen.xml
+++ b/app/src/main/res/drawable/ic_fullscreen.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#000000"
+        android:pathData="M7 14H5v5h5v-2H7v-3zm-2-4h2V7h3V5H5v5zm12 7h-3v2h5v-5h-2v3zM14 5v2h3v3h2V5h-5z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_fullscreen_exit.xml
+++ b/app/src/main/res/drawable/ic_fullscreen_exit.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#000000"
+        android:pathData="M5 16h3v3h2v-5H5v2zm3-8H5v2h5V5H8v3zm6 11h2v-3h3v-2h-5v5zm2-11V5h-2v5h5V8h-3z"/>
+</vector>


### PR DESCRIPTION
## Summary
- Replace text buttons in ReaderScreen with icon-based controls
- Add vector drawable resources for back, forward, camera, and fullscreen toggles

## Testing
- `gradle build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a44b517a348321b42488a9e884b1c1